### PR TITLE
Remove ipam.view_ipaddress permission from IP Pinger

### DIFF
--- a/netbox_ping/navigation.py
+++ b/netbox_ping/navigation.py
@@ -17,13 +17,13 @@ menu_items = (
     PluginMenuItem(
         link='plugins:netbox_ping:ip_pinger',
         link_text='IP Pinger',
-        permissions=('ipam.view_prefix', 'ipam.view_ipaddress'),
+        permissions=('ipam.view_prefix',),
         buttons=(
             PluginMenuButton(
                 link='plugins:netbox_ping:ip_pinger',
                 title='IP Pinger',
                 icon_class='mdi mdi-target',
-                permissions=('ipam.view_prefix', 'ipam.view_ipaddress'),
+                permissions=('ipam.view_prefix',),
             ),
         ),
     ),


### PR DESCRIPTION
Remove the `ipam.view_ipaddress` permission requirement from the IP Pinger menu item and button in the navigation configuration.

Changes:
- Updated PluginMenuItem permissions from `('ipam.view_prefix', 'ipam.view_ipaddress')` to `('ipam.view_prefix',)`
- Updated PluginMenuButton permissions from `('ipam.view_prefix', 'ipam.view_ipaddress')` to `('ipam.view_prefix',)`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c7c780a4084e448d898995cdd36963f7/zenith-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c7c780a4084e448d898995cdd36963f7</projectId>-->
<!--<branchName>zenith-sanctuary</branchName>-->