### PR TITLE
Add PING ALL button to ping all subnets at once

### DIFF
--- a/netbox_ping/templates/netbox_ping/ip_pinger.html
+++ b/netbox_ping/templates/netbox_ping/ip_pinger.html
@@ -367,6 +367,73 @@
       });
   }
 
+  // Function to ping all subnets
+  function pingAllSubnets() {
+    const pingAllButton = document.getElementById("pingAllButton");
+    const originalButtonContent = pingAllButton.innerHTML;
+
+    // Find all ping subnet buttons
+    const subnetButtons = document.querySelectorAll("button[data-prefix-id]");
+
+    if (subnetButtons.length === 0) {
+      alert("No subnets available to ping");
+      return;
+    }
+
+    // Disable the PING ALL button and show loading state
+    pingAllButton.disabled = true;
+    pingAllButton.innerHTML =
+      '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> PINGING ALL...';
+
+    let completedCount = 0;
+    const totalCount = subnetButtons.length;
+
+    // Function to re-enable PING ALL button when all pings are complete
+    function checkCompletion() {
+      completedCount++;
+      if (completedCount >= totalCount) {
+        setTimeout(() => {
+          pingAllButton.disabled = false;
+          pingAllButton.innerHTML = originalButtonContent;
+        }, 1000);
+      }
+    }
+
+    // Click each subnet ping button with a small delay to prevent overwhelming the server
+    subnetButtons.forEach((button, index) => {
+      setTimeout(() => {
+        if (!button.disabled) {
+          const prefixId = button.getAttribute("data-prefix-id");
+          const prefixName = button
+            .closest("tr")
+            .querySelector("td:first-child a")
+            .textContent.trim();
+
+          // Create a custom ping function that includes completion tracking
+          const originalButton = button;
+          const originalOnclick = button.onclick;
+
+          // Temporarily replace the onclick to add completion tracking
+          button.onclick = function () {
+            pingSubnet(this, prefixId, prefixName);
+            // Set a timeout to check completion after ping is likely done
+            setTimeout(checkCompletion, 2000);
+          };
+
+          // Trigger the ping
+          button.click();
+
+          // Restore original onclick after a short delay
+          setTimeout(() => {
+            button.onclick = originalOnclick;
+          }, 100);
+        } else {
+          checkCompletion();
+        }
+      }, index * 300); // 300ms delay between each ping to prevent server overload
+    });
+  }
+
   // Auto-focus search input if present
   document.addEventListener("DOMContentLoaded", function () {
     const searchInput = document.querySelector('input[name="search"]');

--- a/netbox_ping/templates/netbox_ping/ip_pinger.html
+++ b/netbox_ping/templates/netbox_ping/ip_pinger.html
@@ -135,6 +135,29 @@
   </div>
 </div>
 
+<!-- PING ALL Button Section -->
+<div class="row mb-4">
+  <div class="col-12 text-center">
+    <button
+      id="pingAllButton"
+      class="btn btn-success btn-lg px-5 py-3"
+      onclick="pingAllSubnets()"
+      style="
+        font-weight: bold;
+        font-size: 1.2em;
+        letter-spacing: 1px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        border: none;
+      "
+    >
+      <i class="mdi mdi-target-account"></i> PING ALL
+    </button>
+    <div class="mt-2">
+      <small class="text-muted">Click to ping all subnets below</small>
+    </div>
+  </div>
+</div>
+
 <!-- Subnet Ping Table Section -->
 <div class="row">
   <div class="col-12">


### PR DESCRIPTION
Adds a new "PING ALL" button to the IP pinger interface that allows users to ping all available subnets simultaneously.

Changes include:
- Added a centered PING ALL button with success styling and icon
- Implemented pingAllSubnets() JavaScript function to iterate through all subnet ping buttons
- Added loading state with spinner and disabled state during mass ping operation
- Included 300ms delay between pings to prevent server overload
- Added completion tracking to re-enable button when all pings finish
- Added helper text explaining the button functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e112764efdf2415ebfd01013fb580f11/cosmos-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e112764efdf2415ebfd01013fb580f11</projectId>-->
<!--<branchName>cosmos-oasis</branchName>-->