### PR TITLE
Simplify PING ALL button styling and positioning

### DIFF
--- a/netbox_ping/templates/netbox_ping/ip_pinger.html
+++ b/netbox_ping/templates/netbox_ping/ip_pinger.html
@@ -152,7 +152,7 @@
             onmouseout="this.style.backgroundColor='#198754'; this.style.borderColor='#198754'"
           >
             <i class="mdi mdi-target-account me-2"></i>
-            PING ALL SUBNETS
+            PING ALL
           </button>
         </div>
       </div>

--- a/netbox_ping/templates/netbox_ping/ip_pinger.html
+++ b/netbox_ping/templates/netbox_ping/ip_pinger.html
@@ -160,54 +160,6 @@
   </div>
 </div>
 
-<!-- PING ALL Button Section -->
-<div class="row mb-4">
-  <div class="col-12">
-    <div
-      class="card"
-      style="
-        border: 2px solid #28a745;
-        background: linear-gradient(135deg, #f8fff9 0%, #e8f5e8 100%);
-      "
-    >
-      <div class="card-body text-center py-4">
-        <button
-          id="pingAllButton"
-          class="btn btn-success btn-lg px-5 py-3 mb-3"
-          onclick="pingAllSubnets()"
-          style="
-            font-weight: bold;
-            font-size: 1.4em;
-            letter-spacing: 1px;
-            box-shadow: 0 8px 16px rgba(40, 167, 69, 0.4);
-            border: 3px solid #28a745;
-            background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
-            transition: all 0.3s ease;
-            text-transform: uppercase;
-            min-width: 300px;
-            height: 60px;
-          "
-          onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 12px 24px rgba(40, 167, 69, 0.6)'"
-          onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='0 8px 16px rgba(40, 167, 69, 0.4)'"
-        >
-          <i class="mdi mdi-target-account me-2" style="font-size: 1.2em"></i>
-          🎯 PING ALL SUBNETS 🎯
-        </button>
-        <div class="mt-3">
-          <p class="mb-1 text-success fw-bold" style="font-size: 1.1em">
-            <i class="mdi mdi-information-outline me-1"></i>
-            Click to ping all IPs in every subnet below
-          </p>
-          <small class="text-muted" style="font-size: 0.95em">
-            This will automatically click all "Ping Subnet" buttons and show
-            results in the table
-          </small>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
 <!-- Subnet Ping Table Section -->
 <div class="row">
   <div class="col-12">

--- a/netbox_ping/templates/netbox_ping/ip_pinger.html
+++ b/netbox_ping/templates/netbox_ping/ip_pinger.html
@@ -130,6 +130,31 @@
           search_query }}"
         </div>
         {% endif %} {% endif %}
+
+        <!-- PING ALL Button positioned on the right -->
+        <div class="d-flex justify-content-end mt-3">
+          <button
+            id="pingAllButton"
+            class="btn btn-success px-3 py-2"
+            onclick="pingAllSubnets()"
+            style="
+              font-weight: bold;
+              font-size: 1em;
+              letter-spacing: 0.5px;
+              border: 2px solid #198754;
+              background-color: #198754;
+              color: white;
+              text-transform: uppercase;
+              min-width: 180px;
+              transition: all 0.3s ease;
+            "
+            onmouseover="this.style.backgroundColor='#157347'; this.style.borderColor='#146c43'"
+            onmouseout="this.style.backgroundColor='#198754'; this.style.borderColor='#198754'"
+          >
+            <i class="mdi mdi-target-account me-2"></i>
+            PING ALL SUBNETS
+          </button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Refactored the PING ALL button section to use a simpler design:

- Removed the dedicated card container for the button
- Moved button to the right side of the existing card using flexbox
- Simplified button styling by removing gradients, shadows, and hover animations
- Reduced button size and text (from "🎯 PING ALL SUBNETS 🎯" to "PING ALL")
- Removed descriptive text and help information below the button
- Updated color scheme to use standard Bootstrap success colors

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e112764efdf2415ebfd01013fb580f11/zenith-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e112764efdf2415ebfd01013fb580f11</projectId>-->
<!--<branchName>zenith-realm</branchName>-->